### PR TITLE
Update packaging/aur/PKGBUILD

### DIFF
--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -8,7 +8,7 @@ arch=('any')
 url="https://github.com/sys4/libtlsrpt"
 license=('LGPLv3+')
 source=("$pkgname-$pkgver.tar.gz::https://github.com/sys4/libtlsrpt/releases/download/v$pkgver/$pkgname-$pkgver.tar.gz")
-sha256sums=('3c7ebcb4fc93389d14603d5302375a59be429e52dd4c676a6db757ea06226166')
+sha256sums=('90a266d6be3dc3390342614e1f54e1eddf13b0ea208b900740ec01f28f30cd9f')
 
 build() {
   cd "$srcdir/$pkgname-$pkgver"


### PR DESCRIPTION
Correction of the sha256sums for the initial commit to the Archlinux AUR repository