### PR TITLE
Replace stale references to GPLv3 with LGPLv3

### DIFF
--- a/man/Makefile
+++ b/man/Makefile
@@ -3,19 +3,18 @@
 #    Author Boris Lohner bl@sys4.de
 #
 #    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU General Public License as
+#    it under the terms of the GNU Lesser General Public License as
 #    published by the Free Software Foundation, either version 3 of the
 #    License, or (at your option) any later version.
 #
 #    This program is distributed in the hope that it will be useful,
 #    but WITHOUT ANY WARRANTY; without even the implied warranty of
 #    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU General Public License for more details.
+#    GNU Lesser General Public License for more details.
 #
-#    You should have received a copy of the GNU General Public License
-#    along with this program.
+#    You should have received a copy of the GNU Lesser General Public
+#    License along with this program.
 #    If not, see <http://www.gnu.org/licenses/>.
-#
 
 TARGETS = tlsrpt_add_delivery_request_failure.3
 TARGETS += tlsrpt_add_mx_host_pattern.3

--- a/packaging/rpm/libtlsrpt.spec
+++ b/packaging/rpm/libtlsrpt.spec
@@ -3,7 +3,7 @@ Version:        0.5.0
 Release:        1%{?dist}
 Summary:        Interface library to implement TLSRPT reporting into an MTA and to generate and submit TLSRPT reports.
 
-License:        GPLv3+
+License:        LGPLv3+
 URL:            https://github.com/sys4/tlsrpt
 Source0:        libtlsrpt-0.5.0.tar.gz
 


### PR DESCRIPTION
Hi!  I'm maintaining this for Debian, and noticed there were still some references to GPLv3 in this package, which presumably should be LGPLv3, right?

Thanks,
Simon